### PR TITLE
Fixed grammar, made default usage clearer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ Installation
 Usage
 -----
 
-1. create an empty `custom.semantic.json` file somewhere in your project. For example `/client/lib/semantic-ui/custom.semantic.json`.
-2. start meteor
-3. edit the file `custom.semantic.json` to select only the definitions and themes you want
-4. save the file and it will generate Semantic UI
+1. Create an empty `custom.semantic.json` file somewhere in your project. For example `/client/lib/semantic-ui/custom.semantic.json`.
+2. Start meteor
+3. Edit the file `custom.semantic.json` to select only the definitions and themes you want
+4. Save the file and it will generate Semantic UI
 
-> Note: if you are happy with the default values you will need to remove `.custom.semantic.json` to generate Semantic UI. (see Generating Trigger)
+> IMPORTANT: If you are happy with the default values you will NEED to remove `.custom.semantic.json` to generate Semantic UI. (see Generating Trigger)
+
+> NOTE: Another way to use ONLY the default values is to use this package: https://atmospherejs.com/semantic/ui-css
+    meteor add semantic:ui-css
 
 custom.semantic.json
 --------------------
@@ -83,9 +86,9 @@ Generating Trigger
 
 Every time Meteor starts (or refreshes) it calls the package `semantic:ui` to generate Semantic UI.
 
-The package has a simple mechanism based on the difference of `custom.semantic.json` and `.custom.semantic.json` to avoid generating all the time the files and folders.
+The package has a simple mechanism based on the difference of `custom.semantic.json` and `.custom.semantic.json` to avoid generating all the Semantic UI files and folders each time Meteor starts (or refreshes).
 
-Therefore if the file `.custom.semantic.json` does not exist or it is different than `custom.semantic.json` then it will generate Semantic UI.
+Therefore if the file `.custom.semantic.json` does not exist or it is different from `custom.semantic.json` then it will generate Semantic UI.
 
 Dependencies
 ------------


### PR DESCRIPTION
I missed the line about removing `.custom.semantic.json`, thought it should be spelled out a bit more clearly. I read the docs 2 times before, and posted an issue on Stack Overflow, only to find I needed to remove the above mentioned file.
