### PR TITLE
Remove superfluous " in error message.

### DIFF
--- a/data/custom-semantic-data.js
+++ b/data/custom-semantic-data.js
@@ -46,7 +46,7 @@ customSemanticData.requiredThemesNames = function() {
 
 customSemanticData.validate = function(definitionsData, themesData) {
   var throwError = function(name) {
-    throw new Error('definition/theme "' + name + '"" does not exist. Please update your custom.semantic.json file.');
+    throw new Error('definition/theme "' + name + '" does not exist. Please update your custom.semantic.json file.');
   };
   _.each(_.keys(this.data.definitions), function(definitionName) {
     if (!definitionsData.exists(definitionName)) {


### PR DESCRIPTION
Just a minor correction in the error message. It caused me to triple check my own spelling of the theme name before realizing where the extra " came from.
